### PR TITLE
Add explicit source plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j-retry</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j-retry</module>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
fixes warning

```
[WARNING] Some problems were encountered while building the effective model for net.niebes:retrofit-resilience4j-retry:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ net.niebes:retrofit-plugins:1.0.0-SNAPSHOT, /home/travis/build/niebes/retrofit-plugins/pom.xml, line 129, column 21
```