### PR TITLE
Remove exception none tag

### DIFF
--- a/retrofit-metrics-micrometer/README.md
+++ b/retrofit-metrics-micrometer/README.md
@@ -9,7 +9,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | async         | true for `execute()` false for `enqueue()`       |
 | status        | response status                                  |
 | series        | response status family                           |
-| exception     | `simpleName` of the response exception or `None` |
+| exception     | `simpleName` of the response exception           |
 
 
 ## usage

--- a/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
@@ -155,19 +155,18 @@ internal class MicrometerRetrofitMetricsFactoryTest {
 
     private fun meter(method: String, path: String, baseUrl: String, status: String): Timer =
         meterRegistry.get("http.client.requests")
-            .tag("method", method)
-            .tag("uri", path)
             .tag("base_url", baseUrl)
+            .tag("uri", path)
+            .tag("method", method)
             .tag("status", status)
             .tag("series", HttpSeries.fromHttpStatus(status.toInt())!!.name)
-            .tag("exception", "None")
             .timer()
 
     private fun exceptionMeter(method: String, path: String, baseUrl: String, exception: String): Timer =
         meterRegistry.get("http.client.requests")
-            .tag("method", method)
-            .tag("uri", path)
             .tag("base_url", baseUrl)
+            .tag("uri", path)
+            .tag("method", method)
             .tag("exception", exception)
             .timer()
 

--- a/retrofit-metrics-statsd/README.md
+++ b/retrofit-metrics-statsd/README.md
@@ -9,7 +9,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | async         | true for `execute()` false for `enqueue()`       |
 | status        | response status                                  |
 | series        | response status family                           |
-| exception     | `simpleName` of the response exception or `None` |
+| exception     | `simpleName` of the response exception           |
 
 
 ## usage

--- a/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
@@ -85,8 +85,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "GET",
             status = "200",
             series = "SUCCESSFUL",
-            aysnc = "false",
-            exception = "None"
+            aysnc = "false"
         )
     }
 
@@ -103,8 +102,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "GET",
             status = "200",
             series = "SUCCESSFUL",
-            aysnc = "false",
-            exception = "None"
+            aysnc = "false"
         )
     }
 
@@ -121,8 +119,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "GET",
             status = "500",
             series = "SERVER_ERROR",
-            aysnc = "false",
-            exception = "None"
+            aysnc = "false"
         )
     }
 
@@ -156,8 +153,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "FOO",
             status = "200",
             series = "SUCCESSFUL",
-            aysnc = "false",
-            exception = "None"
+            aysnc = "false"
         )
     }
 
@@ -174,8 +170,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "GET",
             status = "200",
             series = "SUCCESSFUL",
-            aysnc = "false",
-            exception = "None"
+            aysnc = "false"
         )
     }
 
@@ -201,8 +196,7 @@ class StatsDRetrofitMetricsFactoryTest {
             method = "GET",
             status = "200",
             series = "SUCCESSFUL",
-            aysnc = "true",
-            exception = "None"
+            aysnc = "true"
         )
     }
 
@@ -212,17 +206,15 @@ class StatsDRetrofitMetricsFactoryTest {
         method: String,
         status: String,
         series: String,
-        aysnc: String,
-        exception: String
+        aysnc: String
     ) {
         verify(statsD).histogram(eq("http.client.requests"), anyLong(),
             eq("base_url:$baseUrl"),
             eq("uri:$path"),
             eq("method:$method"),
-            eq("series:$series"),
-            eq("status:$status"),
             eq("async:$aysnc"),
-            eq("exception:$exception")
+            eq("series:$series"),
+            eq("status:$status")
         )
     }
 
@@ -235,8 +227,8 @@ class StatsDRetrofitMetricsFactoryTest {
     ) {
         verify(statsD).histogram(eq("http.client.requests"), anyLong(),
             eq("base_url:$baseUrl"),
-            eq("method:$method"),
             eq("uri:$path"),
+            eq("method:$method"),
             eq("async:$aysnc"),
             eq("exception:$exception")
         )

--- a/retrofit-metrics/README.md
+++ b/retrofit-metrics/README.md
@@ -10,7 +10,7 @@ this plugin creates metrics with tags.
 | async         | true for `execute()` false for `enqueue()`       |
 | status        | response status                                  |
 | series        | response status family                           |
-| exception     | `simpleName` of the response exception or `None` |
+| exception     | `simpleName` of the response exception           |
 
 You'll need to capture those metrics with a metrics library of your choice.
 

--- a/retrofit-metrics/src/main/kotlin/net/niebes/retrofit/metrics/RetrofitCallMetricsCollector.kt
+++ b/retrofit-metrics/src/main/kotlin/net/niebes/retrofit/metrics/RetrofitCallMetricsCollector.kt
@@ -19,10 +19,9 @@ class RetrofitCallMetricsCollector(
         "base_url" to baseUrl,
         "uri" to uri,
         "method" to request.method,
-        "series" to (HttpSeries.fromHttpStatus(response.code())?.name ?: "UNKNOWN"),
-        "status" to response.code().toString(),
         "async" to async.toString(),
-        "exception" to "None"
+        "series" to (HttpSeries.fromHttpStatus(response.code())?.name ?: "UNKNOWN"),
+        "status" to response.code().toString()
     ), duration)
 
     fun measureRequestException(
@@ -32,8 +31,8 @@ class RetrofitCallMetricsCollector(
         async: Boolean
     ) = metricsRecorder.recordTiming(mapOf(
         "base_url" to baseUrl,
-        "method" to request.method,
         "uri" to uri,
+        "method" to request.method,
         "async" to async.toString(),
         "exception" to throwable.javaClass.simpleName
     ), duration)


### PR DESCRIPTION
we record metrics on two occasion: response and exception
for response we capture status and series, for exception we capture the simple name of the exception class

We should either have all tags for both and find defaults for status and family or only use them when they're available.

In this PR we remove the exception = 'NONE' tag for requests with a response.