### PR TITLE
#136 add default tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,26 +1,27 @@
-root = true
+root=true
 
 [*]
-charset = utf-8
+charset=utf-8
 
 #Four spaces for indent.
-indent_style = space
+indent_style=space
 
 #Four spaces for indent.
-indent_size = 4
+indent_size=4
 
 #Unix line endings.
-end_of_line = lf
+end_of_line=lf
 
 #Line at the end of every file.
-insert_final_newline = true
+insert_final_newline=true
 
-trim_trailing_whitespace = true
+trim_trailing_whitespace=true
 
 [*.{java,kt}]
 #No * imports.
-wildcard_import_limit = 0
-disabled_rules = import-ordering
+wildcard_import_limit=0
+kotlin_imports_layout=idea
+disabled_rules=import-ordering
 
 [*.{yml,yaml,md}]
-indent_size = 2
+indent_size=2

--- a/retrofit-metrics-micrometer/README.md
+++ b/retrofit-metrics-micrometer/README.md
@@ -7,7 +7,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response statusor `Exception`                    |
+| status        | response status or `Exception`                    |
 | series        | response status family or `EXCEPTION             |
 | exception     | `simpleName` of the response exception or `None` |
 

--- a/retrofit-metrics-micrometer/README.md
+++ b/retrofit-metrics-micrometer/README.md
@@ -7,7 +7,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response status or `Exception`                    |
+| status        | response status or `Exception`                   |
 | series        | response status family or `EXCEPTION             |
 | exception     | `simpleName` of the response exception or `None` |
 

--- a/retrofit-metrics-micrometer/README.md
+++ b/retrofit-metrics-micrometer/README.md
@@ -7,9 +7,9 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response status                                  |
-| series        | response status family                           |
-| exception     | `simpleName` of the response exception           |
+| status        | response statusor `Exception`                    |
+| series        | response status family or `EXCEPTION             |
+| exception     | `simpleName` of the response exception or `None` |
 
 
 ## usage

--- a/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
@@ -170,6 +170,7 @@ internal class MicrometerRetrofitMetricsFactoryTest {
             .tag("method", method)
             .tag("status", status)
             .tag("series", HttpSeries.fromHttpStatus(status.toInt())!!.name)
+            .tag("exception", "None")
             .timer()
 
     private fun exceptionMeter(method: String, path: String, baseUrl: String, exception: String): Timer =
@@ -177,6 +178,8 @@ internal class MicrometerRetrofitMetricsFactoryTest {
             .tag("base_url", baseUrl)
             .tag("uri", path)
             .tag("method", method)
+            .tag("status", "Exception")
+            .tag("series", "EXCEPTION")
             .tag("exception", exception)
             .timer()
 

--- a/retrofit-metrics-statsd/README.md
+++ b/retrofit-metrics-statsd/README.md
@@ -7,7 +7,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response statusor `Exception`                    |
+| status        | response status or `Exception`                    |
 | series        | response status family or `EXCEPTION             |
 | exception     | `simpleName` of the response exception or `None` |
 

--- a/retrofit-metrics-statsd/README.md
+++ b/retrofit-metrics-statsd/README.md
@@ -7,7 +7,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response status or `Exception`                    |
+| status        | response status or `Exception`                   |
 | series        | response status family or `EXCEPTION             |
 | exception     | `simpleName` of the response exception or `None` |
 

--- a/retrofit-metrics-statsd/README.md
+++ b/retrofit-metrics-statsd/README.md
@@ -7,9 +7,9 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response status                                  |
-| series        | response status family                           |
-| exception     | `simpleName` of the response exception           |
+| status        | response statusor `Exception`                    |
+| series        | response status family or `EXCEPTION             |
+| exception     | `simpleName` of the response exception or `None` |
 
 
 ## usage

--- a/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
@@ -206,7 +206,7 @@ class StatsDRetrofitMetricsFactoryTest {
         method: String,
         status: String,
         series: String,
-        aysnc: String
+        aysnc: String,
     ) {
         verify(statsD).histogram(
             eq("http.client.requests"), anyLong(),
@@ -214,8 +214,9 @@ class StatsDRetrofitMetricsFactoryTest {
             eq("uri:$path"),
             eq("method:$method"),
             eq("async:$aysnc"),
+            eq("status:$status"),
             eq("series:$series"),
-            eq("status:$status")
+            eq("exception:None"),
         )
     }
 
@@ -224,7 +225,7 @@ class StatsDRetrofitMetricsFactoryTest {
         path: String,
         method: String,
         aysnc: String,
-        exception: String
+        exception: String,
     ) {
         verify(statsD).histogram(
             eq("http.client.requests"), anyLong(),
@@ -232,6 +233,8 @@ class StatsDRetrofitMetricsFactoryTest {
             eq("uri:$path"),
             eq("method:$method"),
             eq("async:$aysnc"),
+            eq("status:Exception"),
+            eq("series:EXCEPTION"),
             eq("exception:$exception")
         )
     }
@@ -252,7 +255,7 @@ class StatsDRetrofitMetricsFactoryTest {
         @GET("api/users/{userId}/foo")
         fun getWithPlaceHolderValue(
             @Path("userId") userId: String,
-            @Header("some") someHeader: String
+            @Header("some") someHeader: String,
         ): Call<NamedObject>
     }
 

--- a/retrofit-metrics/README.md
+++ b/retrofit-metrics/README.md
@@ -8,9 +8,9 @@ this plugin creates metrics with tags.
 | uri           | uri with placeholders                            |
 | method        | http method                                      |
 | async         | true for `execute()` false for `enqueue()`       |
-| status        | response status                                  |
-| series        | response status family                           |
-| exception     | `simpleName` of the response exception           |
+| status        | response statusor `Exception`                    |
+| series        | response status family or `EXCEPTION             |
+| exception     | `simpleName` of the response exception or `None` |
 
 You'll need to capture those metrics with a metrics library of your choice.
 

--- a/retrofit-metrics/src/main/kotlin/net/niebes/retrofit/metrics/RetrofitCallMetricsCollector.kt
+++ b/retrofit-metrics/src/main/kotlin/net/niebes/retrofit/metrics/RetrofitCallMetricsCollector.kt
@@ -22,7 +22,8 @@ class RetrofitCallMetricsCollector(
             "method" to request.method,
             "async" to async.toString(),
             "series" to (HttpSeries.fromHttpStatus(response.code())?.name ?: "UNKNOWN"),
-            "status" to response.code().toString()
+            "status" to response.code().toString(),
+            "exception" to "None",
         ),
         duration
     )
@@ -38,7 +39,9 @@ class RetrofitCallMetricsCollector(
             "uri" to uri,
             "method" to request.method,
             "async" to async.toString(),
-            "exception" to throwable.javaClass.simpleName
+            "exception" to throwable.javaClass.simpleName,
+            "series" to "EXCEPTION",
+            "status" to "Exception"
         ),
         duration
     )


### PR DESCRIPTION
As a metrics user
I want to add default values for all defined tags
So that prometheus can handle both success and exception metrics

Until now, for Success metrics we record:
`base_url`, `uri`, `method`, `async`, `status`, `series`
For exceptions we record:
`base_url`, `uri`, `method`, `async`, `exception`

In https://github.com/niebes/retrofit-plugins/pull/84 I removed the default value for the tag "exception" to gain consistency.
Since prometheus expects the same set of tags this wont work.

Here I'm adding default values for `status`, `series` and `exception` 