### PR TITLE
move request log to debug

### DIFF
--- a/retrofit-metrics-micrometer/src/main/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerMetricsRecorder.kt
+++ b/retrofit-metrics-micrometer/src/main/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerMetricsRecorder.kt
@@ -15,7 +15,8 @@ class MicrometerMetricsRecorder(
     private val metricsKey = customMetricsKey ?: DEFAULT_METRICS_KEY
 
     override fun recordTiming(tags: Map<String, String>, duration: Duration) {
-        log.info("measure {} with tags {} duration {}ms", metricsKey, tags, duration.toMillis())
+        if (log.isDebugEnabled)
+            log.debug("measure {} with tags {} duration {}ms", metricsKey, tags, duration.toMillis())
         meterRegistry.timer(metricsKey, asTags(tags)).record(duration)
     }
 

--- a/retrofit-metrics-statsd/src/main/kotlin/net/niebes/retrofit/metrics/statsd/StatsDMetricsRecorder.kt
+++ b/retrofit-metrics-statsd/src/main/kotlin/net/niebes/retrofit/metrics/statsd/StatsDMetricsRecorder.kt
@@ -10,7 +10,8 @@ class StatsDMetricsRecorder(
 ) : MetricsRecorder {
     private val log = LoggerFactory.getLogger(StatsDMetricsRecorder::class.java)
     override fun recordTiming(tags: Map<String, String>, duration: Duration) {
-        log.info("measure {} with tags {}", KEY, tags)
+        if (log.isDebugEnabled)
+            log.debug("measure {} with tags {}", KEY, tags)
         statsDClient.histogram(KEY, duration.toMillis(), *asTagsArray(tags))
     }
 


### PR DESCRIPTION
most applications run on log level info by default
logging which requests are outgoing helps to understand the application, but is rather level debug than info