### PR TITLE
Release/1.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,13 +229,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,23 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <keyname>5F73B91A736B558A83CFFE6C8F9425EE2F569085</keyname>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <version>0.7.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j-retry</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.17.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j-retry</module>
@@ -208,23 +208,6 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.7</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <keyname>F9BD4EE25C9E4341</keyname>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.16.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.16.0-SNAPSHOT</version>
+                <version>1.17.0</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.16.0-SNAPSHOT</version>
+            <version>1.17.0</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.17.0</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.17.0</version>
+                <version>1.17.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.16.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.16.0-SNAPSHOT</version>
+                <version>1.17.0</version>
             </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.16.0-SNAPSHOT</version>
+            <version>1.17.0</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.17.0</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.17.0</version>
+                <version>1.17.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.16.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.17.0</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.16.0-SNAPSHOT</version>
+        <version>1.17.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.17.0</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- refresh gpg since the old once expired
- sonatype has a new platform. migrating to it and replace the plugin to stay compliant towards their [docs](https://central.sonatype.org/publish/publish-portal-maven/#publishing)
- release 1.17.0