### PR TITLE
add retrofit-resilience4j module for circuit breaker and rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # retrofit-plugins
 
-A collection of retrofit plugins.
-- [resilience4j-retry](./retrofit-resilience4j-retry)
-- [metrics](./retrofit-metrics)
-  - [Micrometer](./retrofit-metrics-micrometer)
-  - [StatsD](./retrofit-metrics-statsd)
+A collection of Retrofit `CallAdapter.Factory` plugins for metrics, resilience, and observability.
+
+## modules
+
+- **[retrofit-resilience4j](./retrofit-resilience4j)** - Circuit breaker and rate limiter for Retrofit using resilience4j 2.4. Drop-in replacement for the discontinued `io.github.resilience4j:resilience4j-retrofit`.
+- **[retrofit-resilience4j-retry](./retrofit-resilience4j-retry)** - Retry with per-request filtering using resilience4j.
+- **[retrofit-metrics](./retrofit-metrics)** - HTTP call metrics recording.
+  - **[retrofit-metrics-micrometer](./retrofit-metrics-micrometer)** - Micrometer implementation.
+  - **[retrofit-metrics-statsd](./retrofit-metrics-statsd)** - StatsD implementation.

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <version>1.20.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
+        <module>retrofit-resilience4j</module>
         <module>retrofit-resilience4j-retry</module>
         <module>retrofit-metrics</module>
         <module>retrofit-metrics-micrometer</module>

--- a/retrofit-resilience4j/README.md
+++ b/retrofit-resilience4j/README.md
@@ -1,0 +1,50 @@
+# retrofit-resilience4j
+
+Drop-in replacement for the discontinued `io.github.resilience4j:resilience4j-retrofit` module.
+
+Provides circuit breaker and rate limiter `CallAdapter.Factory` implementations for Retrofit 3, OkHttp 5, and resilience4j 2.4.
+
+## migrating from resilience4j-retrofit
+
+The original `resilience4j-retrofit` module was removed in resilience4j 2.0 ([#1677](https://github.com/resilience4j/resilience4j/pull/1677)). This module provides equivalent functionality with no vavr dependency.
+
+### dependency
+
+Replace:
+```kotlin
+implementation("io.github.resilience4j:resilience4j-retrofit:1.7.1")
+```
+With:
+```kotlin
+implementation("net.niebes:retrofit-resilience4j:<version>")
+```
+
+### code changes
+
+Circuit breaker — update import and factory name:
+```diff
+-import io.github.resilience4j.retrofit.CircuitBreakerCallAdapter
++import net.niebes.retrofit.resilience4j.CircuitBreakerCallFactory
+
+ Retrofit.Builder()
+-    .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker) { response ->
++    .addCallAdapterFactory(CircuitBreakerCallFactory(circuitBreaker) { response ->
+         response.code() < 500
+     })
+     .build()
+```
+
+Rate limiter — same pattern:
+```diff
+-import io.github.resilience4j.retrofit.RateLimiterCallAdapter
++import net.niebes.retrofit.resilience4j.RateLimiterCallFactory
+
+ Retrofit.Builder()
+-    .addCallAdapterFactory(RateLimiterCallAdapter.of(rateLimiter))
++    .addCallAdapterFactory(RateLimiterCallFactory(rateLimiter))
+     .build()
+```
+
+### retry
+
+The original module included a basic retry adapter. For retry support with configurable per-request filtering (e.g., only retry GET requests), use the [retrofit-resilience4j-retry](../retrofit-resilience4j-retry) module instead.

--- a/retrofit-resilience4j/pom.xml
+++ b/retrofit-resilience4j/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>retrofit-plugins</artifactId>
+        <groupId>net.niebes</groupId>
+        <version>1.20.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>retrofit-resilience4j</name>
+    <artifactId>retrofit-resilience4j</artifactId>
+    <description>Drop-in replacement for the discontinued io.github.resilience4j:resilience4j-retrofit module. Circuit breaker and rate limiter adapters for Retrofit 3 using resilience4j 2.4</description>
+
+    <properties>
+        <resilience4j.version>2.4.0</resilience4j.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-circuitbreaker</artifactId>
+                <version>${resilience4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-ratelimiter</artifactId>
+                <version>${resilience4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>3.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-scalars</artifactId>
+            <version>${retrofit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.github.gantsign.maven</groupId>
+                <artifactId>ktlint-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/retrofit-resilience4j/pom.xml
+++ b/retrofit-resilience4j/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
@@ -73,7 +73,7 @@ private class CircuitBreakingCall<T>(
                 circuitBreaker.onError(
                     elapsed,
                     TimeUnit.NANOSECONDS,
-                    Throwable("Response error: HTTP ${response.code()} - ${response.message()}")
+                    HttpResponseException(response.code(), response.message())
                 )
             }
             return response
@@ -109,7 +109,7 @@ private class CircuitBreakingCall<T>(
                         circuitBreaker.onError(
                             elapsed,
                             TimeUnit.NANOSECONDS,
-                            Throwable("Response error: HTTP ${response.code()} - ${response.message()}")
+                            HttpResponseException(response.code(), response.message())
                         )
                     }
                     callback.onResponse(call, response)

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
@@ -1,0 +1,139 @@
+package net.niebes.retrofit.resilience4j
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.core.StopWatch
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
+
+class CircuitBreakerCallFactory(
+    private val circuitBreaker: CircuitBreaker,
+    private val successResponse: (Response<out Any?>) -> Boolean = { it.isSuccessful },
+) : CallAdapter.Factory() {
+    override fun get(
+        returnType: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit,
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+        val nextCallAdapter = retrofit.nextCallAdapter(this, returnType, annotations)
+        return CircuitBreakerCallAdapter(nextCallAdapter, circuitBreaker, successResponse)
+    }
+
+    companion object {
+        @JvmStatic
+        fun of(circuitBreaker: CircuitBreaker): CircuitBreakerCallFactory = CircuitBreakerCallFactory(circuitBreaker)
+
+        @JvmStatic
+        fun of(
+            circuitBreaker: CircuitBreaker,
+            successResponse: (Response<out Any?>) -> Boolean,
+        ): CircuitBreakerCallFactory = CircuitBreakerCallFactory(circuitBreaker, successResponse)
+    }
+}
+
+private class CircuitBreakerCallAdapter<OriginalType, TargetType : Any>(
+    private val nextCallAdapter: CallAdapter<OriginalType, TargetType>,
+    private val circuitBreaker: CircuitBreaker,
+    private val successResponse: (Response<out Any?>) -> Boolean,
+) : CallAdapter<OriginalType, TargetType> {
+    override fun responseType(): Type = nextCallAdapter.responseType()
+
+    override fun adapt(call: Call<OriginalType>): TargetType =
+        nextCallAdapter.adapt(CircuitBreakingCall(call, circuitBreaker, successResponse))
+}
+
+private class CircuitBreakingCall<T>(
+    private val wrappedCall: Call<T>,
+    private val circuitBreaker: CircuitBreaker,
+    private val successResponse: (Response<out Any?>) -> Boolean,
+) : Call<T> {
+    override fun execute(): Response<T> {
+        circuitBreaker.acquirePermission()
+        val stopWatch = StopWatch.start()
+        try {
+            val response = wrappedCall.execute()
+            val elapsed = stopWatch.stop().toNanos()
+            if (successResponse(response)) {
+                circuitBreaker.onResult(elapsed, TimeUnit.NANOSECONDS, response)
+            } else {
+                circuitBreaker.onError(
+                    elapsed,
+                    TimeUnit.NANOSECONDS,
+                    Throwable("Response error: HTTP ${response.code()} - ${response.message()}")
+                )
+            }
+            return response
+        } catch (exception: Exception) {
+            if (wrappedCall.isCanceled) {
+                circuitBreaker.releasePermission()
+            } else {
+                circuitBreaker.onError(stopWatch.stop().toNanos(), TimeUnit.NANOSECONDS, exception)
+            }
+            throw exception
+        }
+    }
+
+    override fun enqueue(callback: Callback<T>) {
+        try {
+            circuitBreaker.acquirePermission()
+        } catch (e: CallNotPermittedException) {
+            callback.onFailure(wrappedCall, e)
+            return
+        }
+        val startNanos = System.nanoTime()
+        wrappedCall.enqueue(
+            object : Callback<T> {
+                override fun onResponse(
+                    call: Call<T>,
+                    response: Response<T>,
+                ) {
+                    val elapsed = System.nanoTime() - startNanos
+                    if (successResponse(response)) {
+                        circuitBreaker.onResult(elapsed, TimeUnit.NANOSECONDS, response)
+                    } else {
+                        circuitBreaker.onError(
+                            elapsed,
+                            TimeUnit.NANOSECONDS,
+                            Throwable("Response error: HTTP ${response.code()} - ${response.message()}")
+                        )
+                    }
+                    callback.onResponse(call, response)
+                }
+
+                override fun onFailure(
+                    call: Call<T>,
+                    throwable: Throwable,
+                ) {
+                    if (call.isCanceled) {
+                        circuitBreaker.releasePermission()
+                    } else {
+                        circuitBreaker.onError(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS, throwable)
+                    }
+                    callback.onFailure(call, throwable)
+                }
+            }
+        )
+    }
+
+    override fun clone(): Call<T> = CircuitBreakingCall(wrappedCall.clone(), circuitBreaker, successResponse)
+
+    override fun isExecuted(): Boolean = wrappedCall.isExecuted
+
+    override fun isCanceled(): Boolean = wrappedCall.isCanceled
+
+    override fun cancel() = wrappedCall.cancel()
+
+    override fun request(): Request = wrappedCall.request()
+
+    override fun timeout(): Timeout = wrappedCall.timeout()
+}

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactory.kt
@@ -57,7 +57,11 @@ private class CircuitBreakingCall<T>(
     private val circuitBreaker: CircuitBreaker,
     private val successResponse: (Response<out Any?>) -> Boolean,
 ) : Call<T> {
+    @Volatile
+    private var executed = false
+
     override fun execute(): Response<T> {
+        executed = true
         circuitBreaker.acquirePermission()
         val stopWatch = StopWatch.start()
         try {
@@ -84,6 +88,7 @@ private class CircuitBreakingCall<T>(
     }
 
     override fun enqueue(callback: Callback<T>) {
+        executed = true
         try {
             circuitBreaker.acquirePermission()
         } catch (e: CallNotPermittedException) {
@@ -127,7 +132,7 @@ private class CircuitBreakingCall<T>(
 
     override fun clone(): Call<T> = CircuitBreakingCall(wrappedCall.clone(), circuitBreaker, successResponse)
 
-    override fun isExecuted(): Boolean = wrappedCall.isExecuted
+    override fun isExecuted(): Boolean = executed
 
     override fun isCanceled(): Boolean = wrappedCall.isCanceled
 

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/HttpResponseException.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/HttpResponseException.kt
@@ -1,0 +1,6 @@
+package net.niebes.retrofit.resilience4j
+
+class HttpResponseException(
+    val statusCode: Int,
+    message: String,
+) : RuntimeException("HTTP $statusCode - $message")

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
@@ -47,7 +47,11 @@ private class RateLimitingCall<T>(
     private val wrappedCall: Call<T>,
     private val rateLimiter: RateLimiter,
 ) : Call<T> {
+    @Volatile
+    private var executed = false
+
     override fun execute(): Response<T> {
+        executed = true
         try {
             RateLimiter.waitForPermission(rateLimiter)
         } catch (e: RequestNotPermitted) {
@@ -59,6 +63,7 @@ private class RateLimitingCall<T>(
     }
 
     override fun enqueue(callback: Callback<T>) {
+        executed = true
         try {
             RateLimiter.waitForPermission(rateLimiter)
         } catch (e: RequestNotPermitted) {
@@ -79,7 +84,7 @@ private class RateLimitingCall<T>(
 
     override fun clone(): Call<T> = RateLimitingCall(wrappedCall.clone(), rateLimiter)
 
-    override fun isExecuted(): Boolean = wrappedCall.isExecuted
+    override fun isExecuted(): Boolean = executed
 
     override fun isCanceled(): Boolean = wrappedCall.isCanceled
 

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
@@ -1,0 +1,90 @@
+package net.niebes.retrofit.resilience4j
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RequestNotPermitted
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+class RateLimiterCallFactory(
+    private val rateLimiter: RateLimiter,
+) : CallAdapter.Factory() {
+    override fun get(
+        returnType: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit,
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+        val nextCallAdapter = retrofit.nextCallAdapter(this, returnType, annotations)
+        return RateLimiterCallAdapter(nextCallAdapter, rateLimiter)
+    }
+
+    companion object {
+        @JvmStatic
+        fun of(rateLimiter: RateLimiter): RateLimiterCallFactory = RateLimiterCallFactory(rateLimiter)
+    }
+}
+
+private class RateLimiterCallAdapter<OriginalType, TargetType : Any>(
+    private val nextCallAdapter: CallAdapter<OriginalType, TargetType>,
+    private val rateLimiter: RateLimiter,
+) : CallAdapter<OriginalType, TargetType> {
+    override fun responseType(): Type = nextCallAdapter.responseType()
+
+    override fun adapt(call: Call<OriginalType>): TargetType = nextCallAdapter.adapt(RateLimitingCall(call, rateLimiter))
+}
+
+private class RateLimitingCall<T>(
+    private val wrappedCall: Call<T>,
+    private val rateLimiter: RateLimiter,
+) : Call<T> {
+    override fun execute(): Response<T> =
+        try {
+            RateLimiter.waitForPermission(rateLimiter)
+            wrappedCall.execute()
+        } catch (e: RequestNotPermitted) {
+            tooManyRequestsError()
+        } catch (e: IllegalStateException) {
+            tooManyRequestsError()
+        }
+
+    override fun enqueue(callback: Callback<T>) {
+        try {
+            RateLimiter.waitForPermission(rateLimiter)
+        } catch (e: RequestNotPermitted) {
+            callback.onResponse(wrappedCall, tooManyRequestsError())
+            return
+        } catch (e: IllegalStateException) {
+            callback.onResponse(wrappedCall, tooManyRequestsError())
+            return
+        }
+        wrappedCall.enqueue(callback)
+    }
+
+    private fun tooManyRequestsError(): Response<T> =
+        Response.error(
+            429,
+            "Too many requests for the client".toResponseBody("text/plain".toMediaType())
+        )
+
+    override fun clone(): Call<T> = RateLimitingCall(wrappedCall.clone(), rateLimiter)
+
+    override fun isExecuted(): Boolean = wrappedCall.isExecuted
+
+    override fun isCanceled(): Boolean = wrappedCall.isCanceled
+
+    override fun cancel() = wrappedCall.cancel()
+
+    override fun request(): Request = wrappedCall.request()
+
+    override fun timeout(): Timeout = wrappedCall.timeout()
+}

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactory.kt
@@ -47,15 +47,16 @@ private class RateLimitingCall<T>(
     private val wrappedCall: Call<T>,
     private val rateLimiter: RateLimiter,
 ) : Call<T> {
-    override fun execute(): Response<T> =
+    override fun execute(): Response<T> {
         try {
             RateLimiter.waitForPermission(rateLimiter)
-            wrappedCall.execute()
         } catch (e: RequestNotPermitted) {
-            tooManyRequestsError()
+            return tooManyRequestsError()
         } catch (e: IllegalStateException) {
-            tooManyRequestsError()
+            return tooManyRequestsError()
         }
+        return wrappedCall.execute()
+    }
 
     override fun enqueue(callback: Callback<T>) {
         try {

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
@@ -1,0 +1,313 @@
+package net.niebes.retrofit.resilience4j
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@WireMockTest
+internal class CircuitBreakerCallFactoryTest {
+    private lateinit var circuitBreaker: CircuitBreaker
+
+    @BeforeEach
+    fun before() {
+        circuitBreaker =
+            CircuitBreaker.of(
+                "test",
+                CircuitBreakerConfig
+                    .custom()
+                    .slidingWindowSize(2)
+                    .minimumNumberOfCalls(2)
+                    .failureRateThreshold(50f)
+                    .waitDurationInOpenState(Duration.ofSeconds(60))
+                    .build()
+            )
+    }
+
+    @Test
+    fun `successful response records success`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(0)
+        verify(1, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `server error records failure with default predicate`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withStatus(500).withBody("error")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(500)
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `custom success predicate treats 4xx as success`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withStatus(404).withBody("not found")))
+        val client =
+            createClient(
+                wmRuntimeInfo,
+                CircuitBreakerCallFactory(circuitBreaker) { it.code() < 500 }
+            )
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(404)
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `open circuit throws CallNotPermittedException on execute`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        circuitBreaker.transitionToOpenState()
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        assertThrows(CallNotPermittedException::class.java) {
+            client.get().execute()
+        }
+        verify(0, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `open circuit calls onFailure on enqueue`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        circuitBreaker.transitionToOpenState()
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val latch = CountDownLatch(1)
+        val failureRef = AtomicReference<Throwable>()
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    fail("expected failure")
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    failureRef.set(throwable)
+                    latch.countDown()
+                }
+            }
+        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(failureRef.get()).isInstanceOf(CallNotPermittedException::class.java)
+        verify(0, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `timeout records circuit breaker error`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withFixedDelay(2000)))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        try {
+            client.get().execute()
+        } catch (_: Exception) {
+        }
+
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `async success callback records success`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val latch = CountDownLatch(1)
+        val responseRef = AtomicReference<Response<String>>()
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    responseRef.set(response)
+                    latch.countDown()
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    fail("no exception expected", throwable)
+                }
+            }
+        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(responseRef.get().code()).isEqualTo(200)
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `async error callback records failure`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withFixedDelay(2000)))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val latch = CountDownLatch(1)
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    fail("expected failure")
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    latch.countDown()
+                }
+            }
+        )
+
+        latch.await(2, TimeUnit.SECONDS)
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `async server error records failure`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withStatus(500).withBody("error")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val latch = CountDownLatch(1)
+        val responseRef = AtomicReference<Response<String>>()
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    responseRef.set(response)
+                    latch.countDown()
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    fail("expected onResponse with 500", throwable)
+                }
+            }
+        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(responseRef.get().code()).isEqualTo(500)
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `cancellation releases permission without recording error`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withFixedDelay(2000)))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val call = client.get()
+
+        kotlin.concurrent.thread {
+            Thread.sleep(50)
+            call.cancel()
+        }
+
+        try {
+            call.execute()
+        } catch (_: Exception) {
+        }
+
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(0)
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(0)
+        assertThat(circuitBreaker.metrics.numberOfNotPermittedCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `enough failures transition circuit to open`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withStatus(500).withBody("error")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        client.get().execute()
+        client.get().execute()
+
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+        assertThrows(CallNotPermittedException::class.java) {
+            client.get().execute()
+        }
+    }
+
+    @Test
+    fun `clone produces usable independent call`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+        val original = client.get()
+        original.execute()
+
+        val cloned = original.clone()
+        val response = cloned.execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        verify(2, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `of factory method creates working adapter`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val factory = CircuitBreakerCallFactory.of(circuitBreaker) { it.code() < 500 }
+        val client = createClient(wmRuntimeInfo, factory)
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
+    }
+
+    private fun createClient(
+        wmRuntimeInfo: WireMockRuntimeInfo,
+        factory: CircuitBreakerCallFactory,
+    ): TestClient =
+        Retrofit
+            .Builder()
+            .client(
+                OkHttpClient
+                    .Builder()
+                    .connectTimeout(Duration.ofMillis(500))
+                    .readTimeout(Duration.ofMillis(500))
+                    .writeTimeout(Duration.ofMillis(500))
+                    .build()
+            ).addConverterFactory(ScalarsConverterFactory.create())
+            .addCallAdapterFactory(factory)
+            .baseUrl(wmRuntimeInfo.httpBaseUrl)
+            .build()
+            .create(TestClient::class.java)
+}

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
@@ -123,7 +123,7 @@ internal class CircuitBreakerCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS)
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue()
         assertThat(failureRef.get()).isInstanceOf(CallNotPermittedException::class.java)
         verify(0, getRequestedFor(urlEqualTo("/api/test")))
     }
@@ -167,7 +167,7 @@ internal class CircuitBreakerCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS)
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue()
         assertThat(responseRef.get().code()).isEqualTo(200)
         assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
     }
@@ -226,7 +226,7 @@ internal class CircuitBreakerCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS)
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue()
         assertThat(responseRef.get().code()).isEqualTo(500)
         assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
     }
@@ -247,6 +247,7 @@ internal class CircuitBreakerCallFactoryTest {
         } catch (_: Exception) {
         }
 
+        assertThat(call.isCanceled).isTrue()
         assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(0)
         assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(0)
         assertThat(circuitBreaker.metrics.numberOfNotPermittedCalls).isEqualTo(0)

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactoryTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactoryTest.kt
@@ -1,0 +1,200 @@
+package net.niebes.retrofit.resilience4j
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@WireMockTest
+internal class RateLimiterCallFactoryTest {
+    @Test
+    fun `request permitted passes through`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val rateLimiter = createRateLimiter(limitForPeriod = 10)
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        assertThat(response.body()).isEqualTo("ok")
+        verify(1, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `rate limited execute returns 429`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        val rateLimiter = createExhaustedRateLimiter()
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+
+        val response = client.get().execute()
+
+        assertThat(response.code()).isEqualTo(429)
+        verify(0, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `rate limited enqueue returns 429 via onResponse`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        val rateLimiter = createExhaustedRateLimiter()
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+        val latch = CountDownLatch(1)
+        val responseRef = AtomicReference<Response<String>>()
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    responseRef.set(response)
+                    latch.countDown()
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    fail("expected onResponse with 429, not onFailure", throwable)
+                }
+            }
+        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(responseRef.get().code()).isEqualTo(429)
+        verify(0, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `multiple requests within limit succeed`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val rateLimiter = createRateLimiter(limitForPeriod = 5)
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+
+        repeat(3) {
+            val response = client.get().execute()
+            assertThat(response.code()).isEqualTo(200)
+        }
+
+        verify(3, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `rate limited 429 response contains expected body`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        val rateLimiter = createExhaustedRateLimiter()
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+
+        val response = client.get().execute()
+
+        assertThat(response.errorBody()?.string()).isEqualTo("Too many requests for the client")
+    }
+
+    @Test
+    fun `async request permitted passes through`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val rateLimiter = createRateLimiter(limitForPeriod = 10)
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+        val latch = CountDownLatch(1)
+        val responseRef = AtomicReference<Response<String>>()
+
+        client.get().enqueue(
+            object : Callback<String> {
+                override fun onResponse(
+                    call: Call<String>,
+                    response: Response<String>,
+                ) {
+                    responseRef.set(response)
+                    latch.countDown()
+                }
+
+                override fun onFailure(
+                    call: Call<String>,
+                    throwable: Throwable,
+                ) {
+                    fail("no exception expected", throwable)
+                }
+            }
+        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(responseRef.get().code()).isEqualTo(200)
+        assertThat(responseRef.get().body()).isEqualTo("ok")
+        verify(1, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    @Test
+    fun `clone produces usable independent call`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("ok")))
+        val rateLimiter = createRateLimiter(limitForPeriod = 10)
+        val client = createClient(wmRuntimeInfo, RateLimiterCallFactory(rateLimiter))
+        val original = client.get()
+        original.execute()
+
+        val cloned = original.clone()
+        val response = cloned.execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        verify(2, getRequestedFor(urlEqualTo("/api/test")))
+    }
+
+    private fun createRateLimiter(limitForPeriod: Int): RateLimiter =
+        RateLimiter.of(
+            "test",
+            RateLimiterConfig
+                .custom()
+                .limitForPeriod(limitForPeriod)
+                .limitRefreshPeriod(Duration.ofSeconds(1))
+                .timeoutDuration(Duration.ofMillis(100))
+                .build()
+        )
+
+    private fun createExhaustedRateLimiter(): RateLimiter {
+        val rateLimiter =
+            RateLimiter.of(
+                "test",
+                RateLimiterConfig
+                    .custom()
+                    .limitForPeriod(1)
+                    .limitRefreshPeriod(Duration.ofSeconds(60))
+                    .timeoutDuration(Duration.ZERO)
+                    .build()
+            )
+        rateLimiter.acquirePermission()
+        return rateLimiter
+    }
+
+    private fun createClient(
+        wmRuntimeInfo: WireMockRuntimeInfo,
+        factory: RateLimiterCallFactory,
+    ): TestClient =
+        Retrofit
+            .Builder()
+            .client(
+                OkHttpClient
+                    .Builder()
+                    .connectTimeout(Duration.ofSeconds(1))
+                    .readTimeout(Duration.ofSeconds(1))
+                    .writeTimeout(Duration.ofSeconds(1))
+                    .build()
+            ).addConverterFactory(ScalarsConverterFactory.create())
+            .addCallAdapterFactory(factory)
+            .baseUrl(wmRuntimeInfo.httpBaseUrl)
+            .build()
+            .create(TestClient::class.java)
+}

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactoryTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/RateLimiterCallFactoryTest.kt
@@ -76,7 +76,7 @@ internal class RateLimiterCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS)
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue()
         assertThat(responseRef.get().code()).isEqualTo(429)
         verify(0, getRequestedFor(urlEqualTo("/api/test")))
     }
@@ -132,7 +132,7 @@ internal class RateLimiterCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS)
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue()
         assertThat(responseRef.get().code()).isEqualTo(200)
         assertThat(responseRef.get().body()).isEqualTo("ok")
         verify(1, getRequestedFor(urlEqualTo("/api/test")))

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/TestClient.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/TestClient.kt
@@ -1,0 +1,13 @@
+package net.niebes.retrofit.resilience4j
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+internal interface TestClient {
+    @GET("api/test")
+    fun get(): Call<String>
+
+    @POST("api/test")
+    fun post(): Call<String>
+}


### PR DESCRIPTION
## Summary

- Ports the dropped `resilience4j-retrofit` module (last in v1.7.1, removed in v2.0) to work with **resilience4j 2.4.0**, **Retrofit 3**, and **OkHttp 5**
- Provides `CircuitBreakerCallFactory` and `RateLimiterCallFactory` as `CallAdapter.Factory` implementations
- Eliminates the **vavr dependency** from the original module entirely
- For retry support, use the existing `retrofit-resilience4j-retry` module
- Tests use **WireMock** (20 tests: 13 circuit breaker, 7 rate limiter)

## Test plan

- [ ] `./mvnw verify` passes all modules
- [ ] `./mvnw dependency:tree -pl retrofit-resilience4j` shows resilience4j 2.4.0, no vavr
- [ ] Circuit breaker: sync/async success, failure, timeout, cancellation, state transition, clone
- [ ] Rate limiter: sync/async permitted, 429 on exhaustion, body content, clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)