### PR TITLE
migrate tests from MockWebServer to WireMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,16 +102,10 @@
             </dependency>
 
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>mockwebserver3-junit5</artifactId>
-                <version>${okhttp.version}</version>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>3.13.0</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.squareup.okhttp3</groupId>
-                        <artifactId>okhttp-jvm</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.squareup.retrofit2</groupId>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -80,8 +80,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver3-junit5</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-micrometer/src/test/kotlin/net/niebes/retrofit/metrics/micrometer/MicrometerRetrofitMetricsFactoryTest.kt
@@ -1,17 +1,21 @@
 package net.niebes.retrofit.metrics.micrometer
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.any
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
 import net.niebes.retrofit.metrics.HttpSeries
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Call
@@ -26,19 +30,19 @@ import retrofit2.http.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@WireMockTest
 internal class MicrometerRetrofitMetricsFactoryTest {
-    private val responseBody = "{ \"name\": \"The body with no name\" }"
+    private val responseBody = """{ "name": "The body with no name" }"""
     private val responseObject = NamedObject("The body with no name")
 
-    private lateinit var server: MockWebServer
     private lateinit var client: SomeClient
     private lateinit var meterRegistry: MeterRegistry
+    private lateinit var baseUrl: String
 
     @BeforeEach
-    fun before() {
-        server = MockWebServer()
-        server.start()
+    fun before(wmRuntimeInfo: WireMockRuntimeInfo) {
         meterRegistry = SimpleMeterRegistry()
+        baseUrl = wmRuntimeInfo.httpBaseUrl + "/"
 
         val okHttpClient =
             OkHttpClient
@@ -47,92 +51,80 @@ internal class MicrometerRetrofitMetricsFactoryTest {
                 .readTimeout(1000, TimeUnit.MILLISECONDS)
                 .writeTimeout(1000, TimeUnit.MILLISECONDS)
                 .build()
-        val baseUrl = server.url("/")
         val retrofit =
             Retrofit
                 .Builder()
                 .client(okHttpClient)
                 .addConverterFactory(JacksonConverterFactory.create(jacksonObjectMapper()))
                 .addCallAdapterFactory(MicrometerRetrofitMetricsFactory(meterRegistry))
-                .baseUrl(baseUrl.toString())
+                .baseUrl(baseUrl)
                 .build()
         client = retrofit.create(SomeClient::class.java)
     }
 
-    private fun addResponse(mockResponse: MockResponse) {
-        server.enqueue(mockResponse)
-    }
-
-    @AfterEach
-    fun after() {
-        server.close()
-    }
-
     @Test
     fun root() {
-        addResponse(
-            MockResponse(body = responseBody)
-        )
-        val response = client.root().execute()
-        assertResponse(response, 200, responseObject)
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
 
-        assertThat(meter("GET", "/", baseUrl(), "200").count()).isEqualTo(1)
+        val response = client.root().execute()
+
+        assertResponse(response, 200, responseObject)
+        assertThat(meter("GET", "/", baseUrl, "200").count()).isEqualTo(1)
     }
 
     @Test
     fun rootWithTimeout() {
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withFixedDelay(5000)))
+
         assertThatThrownBy { client.root().execute() }
 
-        assertThat(exceptionMeter("GET", "/", baseUrl(), "SocketTimeoutException").count()).isEqualTo(1)
+        assertThat(exceptionMeter("GET", "/", baseUrl, "SocketTimeoutException").count()).isEqualTo(1)
     }
 
     @Test
     fun rootWith500() {
-        addResponse(
-            MockResponse(body = responseBody, code = 500)
-        )
-        val response = client.root().execute()
-        assertThat(response.code()).isEqualTo(500)
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(500).withBody(responseBody)))
 
-        assertThat(meter("GET", "/", baseUrl(), "500").count()).isEqualTo(1)
+        val response = client.root().execute()
+
+        assertThat(response.code()).isEqualTo(500)
+        assertThat(meter("GET", "/", baseUrl, "500").count()).isEqualTo(1)
     }
 
     @Test
     fun dotNotation() {
-        addResponse(
-            MockResponse(body = responseBody)
-        )
-        val response = client.dotNotation().execute()
-        assertResponse(response, 200, responseObject)
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
 
-        assertThat(meter("GET", ".", baseUrl(), "200").count()).isEqualTo(1)
+        val response = client.dotNotation().execute()
+
+        assertResponse(response, 200, responseObject)
+        assertThat(meter("GET", ".", baseUrl, "200").count()).isEqualTo(1)
     }
 
     @Test
     fun customHttpMethod() {
-        addResponse(
-            MockResponse(body = responseBody)
-        )
-        val response = client.customHTTPMethod().execute()
-        assertResponse(response, 200, responseObject)
+        stubFor(any(urlEqualTo("/custom/method")).willReturn(aResponse().withBody(responseBody)))
 
-        assertThat(meter("FOO", "/custom/method", baseUrl(), "200").count()).isEqualTo(1)
+        val response = client.customHTTPMethod().execute()
+
+        assertResponse(response, 200, responseObject)
+        assertThat(meter("FOO", "/custom/method", baseUrl, "200").count()).isEqualTo(1)
     }
 
     @Test
     fun usesPlaceholder() {
-        addResponse(
-            MockResponse(body = responseBody)
-        )
+        stubFor(get(urlEqualTo("/api/users/foo/foo")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.getWithPlaceHolderValue("foo", "bar").execute()
+
         assertResponse(response, 200, responseObject)
-        assertThat(meter("GET", "api/users/{userId}/foo", baseUrl(), "200").count()).isEqualTo(1)
+        assertThat(meter("GET", "api/users/{userId}/foo", baseUrl, "200").count()).isEqualTo(1)
     }
 
     @Test
     fun async() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(get(urlEqualTo("/api/users/userId/foo")).willReturn(aResponse().withBody(responseBody)))
+
         val latch = CountDownLatch(1)
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
             object : Callback<NamedObject> {
@@ -151,11 +143,9 @@ internal class MicrometerRetrofitMetricsFactoryTest {
                 }
             }
         )
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
-        assertThat(meter("GET", "api/users/{userId}/foo", baseUrl(), "200").count()).isEqualTo(1)
+        latch.await(1, TimeUnit.SECONDS)
+        assertThat(meter("GET", "api/users/{userId}/foo", baseUrl, "200").count()).isEqualTo(1)
     }
-
-    private fun baseUrl() = server.url("/").toString()
 
     private fun assertResponse(
         response: Response<NamedObject>,
@@ -205,14 +195,11 @@ internal class MicrometerRetrofitMetricsFactoryTest {
         }.hasCauseInstanceOf(IllegalArgumentException::class.java)
     }
 
-    /**
-     * A test client interface
-     */
     interface SomeClient {
         @GET("/")
         fun root(): Call<NamedObject>
 
-        @GET(".") // uses base url without path
+        @GET(".")
         fun dotNotation(): Call<NamedObject>
 
         @GET("/throws/exception")
@@ -228,9 +215,6 @@ internal class MicrometerRetrofitMetricsFactoryTest {
         ): Call<NamedObject>
     }
 
-    /**
-     * A test data class
-     */
     data class NamedObject(
         val name: String,
     )

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver3-junit5</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics-statsd/src/test/kotlin/net/niebes/retrofit/metrics/statsd/StatsDRetrofitMetricsFactoryTest.kt
@@ -2,12 +2,16 @@ package net.niebes.retrofit.metrics.statsd
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.any
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import com.timgroup.statsd.StatsDClient
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
@@ -29,17 +33,17 @@ import java.net.HttpURLConnection
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@WireMockTest
 class StatsDRetrofitMetricsFactoryTest {
-    private val responseBody = "{ \"name\": \"The body with no name\" }"
+    private val responseBody = """{ "name": "The body with no name" }"""
     private val responseObject = NamedObject("The body with no name")
     private val statsD = mock(StatsDClient::class.java)
-    private lateinit var server: MockWebServer
     private lateinit var client: SomeClient
+    private lateinit var baseUrl: String
 
     @BeforeEach
-    fun setUp() {
-        server = MockWebServer()
-        server.start()
+    fun setUp(wmRuntimeInfo: WireMockRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.httpBaseUrl + "/"
         val okHttpClient =
             OkHttpClient
                 .Builder()
@@ -53,41 +57,21 @@ class StatsDRetrofitMetricsFactoryTest {
                 .client(okHttpClient)
                 .addConverterFactory(JacksonConverterFactory.create(ObjectMapper().registerKotlinModule()))
                 .addCallAdapterFactory(StatsDRetrofitMetricsFactory(statsD))
-                .baseUrl(server.url("/").toString())
+                .baseUrl(baseUrl)
                 .build()
         client = retrofit.create(SomeClient::class.java)
         reset(statsD)
     }
 
-    @AfterEach
-    fun tearDown() {
-        server.close()
-    }
-
-    private fun addResponse(mockResponse: MockResponse) {
-        server.enqueue(mockResponse)
-    }
-
-    private fun baseUrl(): String = server.url("/").toString()
-
-    private fun assertResponse(
-        response: Response<NamedObject>,
-        status: Int,
-        body: Any,
-    ) {
-        assertThat(response.code()).isEqualTo(status)
-        assertThat(response.body()).isEqualTo(body)
-    }
-
     @Test
     fun root() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.root().execute()
 
         assertResponse(response, HttpURLConnection.HTTP_OK, responseObject)
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "/",
             method = "GET",
             status = "200",
@@ -98,13 +82,13 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun dotNotation() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.dotNotation().execute()
 
         assertResponse(response, HttpURLConnection.HTTP_OK, responseObject)
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = ".",
             method = "GET",
             status = "200",
@@ -115,13 +99,13 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun rootWith500() {
-        addResponse(MockResponse(body = responseBody, code = 500))
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(500).withBody(responseBody)))
 
         val response = client.root().execute()
 
         assertThat(response.code()).isEqualTo(500)
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "/",
             method = "GET",
             status = "500",
@@ -132,6 +116,8 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun rootWithTimeout() {
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withFixedDelay(5000)))
+
         try {
             client.root().execute()
             fail("exception expected")
@@ -139,7 +125,7 @@ class StatsDRetrofitMetricsFactoryTest {
         }
 
         verifyExceptionMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "/",
             method = "GET",
             async = "false",
@@ -149,13 +135,13 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun customHttpMethod() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(any(urlEqualTo("/custom/method")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.customHTTPMethod().execute()
 
         assertResponse(response, HttpURLConnection.HTTP_OK, responseObject)
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "/custom/method",
             method = "FOO",
             status = "200",
@@ -166,13 +152,13 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun useUriPlaceHolder() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(get(urlEqualTo("/api/users/userId/foo")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.getWithPlaceHolderValue("userId", "headerValue").execute()
 
         assertResponse(response, HttpURLConnection.HTTP_OK, responseObject)
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "api/users/{userId}/foo",
             method = "GET",
             status = "200",
@@ -183,7 +169,7 @@ class StatsDRetrofitMetricsFactoryTest {
 
     @Test
     fun async() {
-        addResponse(MockResponse(body = responseBody))
+        stubFor(get(urlEqualTo("/api/users/userId/foo")).willReturn(aResponse().withBody(responseBody)))
 
         val latch = CountDownLatch(1)
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
@@ -203,16 +189,25 @@ class StatsDRetrofitMetricsFactoryTest {
                 }
             }
         )
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
+        latch.await(1, TimeUnit.SECONDS)
 
         verifyRequestMetrics(
-            baseUrl = baseUrl(),
+            baseUrl = baseUrl,
             path = "api/users/{userId}/foo",
             method = "GET",
             status = "200",
             series = "SUCCESSFUL",
             async = "true"
         )
+    }
+
+    private fun assertResponse(
+        response: Response<NamedObject>,
+        status: Int,
+        body: Any,
+    ) {
+        assertThat(response.code()).isEqualTo(status)
+        assertThat(response.body()).isEqualTo(body)
     }
 
     private fun verifyRequestMetrics(
@@ -256,15 +251,12 @@ class StatsDRetrofitMetricsFactoryTest {
         )
     }
 
-    /**
-     * A test client interface
-     */
     internal interface SomeClient {
         @GET("/")
         fun root(): Call<NamedObject>
 
         @GET(".")
-        fun dotNotation(): Call<NamedObject> // uses base url without path
+        fun dotNotation(): Call<NamedObject>
 
         @HTTP(method = "FOO", path = "/custom/method")
         fun customHTTPMethod(): Call<NamedObject>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver3-junit5</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>

--- a/retrofit-metrics/src/test/kotlin/net/niebes/retrofit/metrics/RetrofitMetricsFactoryTest.kt
+++ b/retrofit-metrics/src/test/kotlin/net/niebes/retrofit/metrics/RetrofitMetricsFactoryTest.kt
@@ -1,10 +1,20 @@
 package net.niebes.retrofit.metrics
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.any
+import com.github.tomakehurst.wiremock.client.WireMock.delete
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.head
+import com.github.tomakehurst.wiremock.client.WireMock.options
+import com.github.tomakehurst.wiremock.client.WireMock.patch
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.put
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Call
@@ -20,6 +30,7 @@ import retrofit2.http.POST
 import retrofit2.http.PUT
 import java.time.Duration
 
+@WireMockTest
 internal class RetrofitMetricsFactoryTest {
     private val recordedCalls = mutableListOf<Pair<Map<String, String>, Duration>>()
 
@@ -33,30 +44,24 @@ internal class RetrofitMetricsFactoryTest {
             }
         }
 
-    private lateinit var server: MockWebServer
     private lateinit var retrofit: Retrofit
+    private lateinit var baseUrl: String
 
     @BeforeEach
-    fun setUp() {
-        server = MockWebServer()
-        server.start()
+    fun setUp(wmRuntimeInfo: WireMockRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.httpBaseUrl + "/"
         retrofit =
             Retrofit
                 .Builder()
-                .baseUrl(server.url("/"))
+                .baseUrl(baseUrl)
                 .addConverterFactory(JacksonConverterFactory.create(jacksonObjectMapper()))
                 .addCallAdapterFactory(RetrofitMetricsFactory(metricsRecorder))
                 .build()
     }
 
-    @AfterEach
-    fun tearDown() {
-        server.close()
-    }
-
     @Test
     fun `records metrics for GET request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.get().execute()
@@ -68,7 +73,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for POST request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(post(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.post().execute()
@@ -80,7 +85,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for PUT request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(put(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.put().execute()
@@ -91,7 +96,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for DELETE request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(delete(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.delete().execute()
@@ -102,7 +107,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for PATCH request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(patch(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.patch().execute()
@@ -113,7 +118,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for OPTIONS request`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(options(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.options().execute()
@@ -124,7 +129,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for HEAD request`() {
-        server.enqueue(MockResponse())
+        stubFor(head(urlEqualTo("/api/test")).willReturn(aResponse()))
         val client = retrofit.create(TestClient::class.java)
 
         client.head().execute()
@@ -135,7 +140,7 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records metrics for custom HTTP method`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(any(urlEqualTo("/api/custom")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.custom().execute()
@@ -147,12 +152,12 @@ internal class RetrofitMetricsFactoryTest {
 
     @Test
     fun `records base_url tag`() {
-        server.enqueue(MockResponse(body = """{"value":"ok"}"""))
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withBody("""{"value":"ok"}""")))
         val client = retrofit.create(TestClient::class.java)
 
         client.get().execute()
 
-        assertThat(recordedCalls.first().first).containsEntry("base_url", server.url("/").toString())
+        assertThat(recordedCalls.first().first).containsEntry("base_url", baseUrl)
     }
 
     interface TestClient {

--- a/retrofit-resilience4j-retry/README.md
+++ b/retrofit-resilience4j-retry/README.md
@@ -24,14 +24,14 @@ Retrofit.Builder()
     .build().create(MyApi::class.java)
 ```
 
-The request gets retried when it result's in either (1) any* exception or (1) your configured `retryOnResult` evaluates
- to true
-* So far this wrapper retries all exceptions. While this might make sense for e.g. a SocketTimeout it might not for
- e.g. an SslException.
+The request gets retried when it results in either (1) any* exception or (2) your configured `retryOnResult` evaluates
+ to true.
+
+*By default this wrapper retries all exceptions. While this might make sense for a SocketTimeout, it might not for
+ an SslException.
 
 
-By default only GET requests get retried. To Retry different requests you can add your own clause
-e.g.
+By default only GET requests get retried. To retry different requests you can add your own clause:
 ```kotlin
     .addCallAdapterFactory(RetryCallFactory(
         retry = Retry.of("my-api-client", RetryConfig.custom<Response<out Any>>()

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -63,8 +63,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver3-junit5</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/retrofit-resilience4j-retry/src/test/kotlin/net/niebes/resilience4j/RetryCallFactoryTest.kt
+++ b/retrofit-resilience4j-retry/src/test/kotlin/net/niebes/resilience4j/RetryCallFactoryTest.kt
@@ -90,7 +90,7 @@ internal class RetryCallFactoryTest {
             .create(SomeClient::class.java)
 
     @Test
-    fun `should not retry with sucessfull response`() {
+    fun `should not retry with successful response`() {
         stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
 
         val response = client.root().execute()
@@ -293,7 +293,7 @@ internal class RetryCallFactoryTest {
     }
 
     @Test
-    fun `should report success when retry condition not met but now exception thrown`() {
+    fun `should report success when retry condition not met but no exception thrown`() {
         stubFor(
             get(urlEqualTo("/api/users/userId/foo"))
                 .willReturn(aResponse().withStatus(500).withBody(responseBody))

--- a/retrofit-resilience4j-retry/src/test/kotlin/net/niebes/resilience4j/RetryCallFactoryTest.kt
+++ b/retrofit-resilience4j-retry/src/test/kotlin/net/niebes/resilience4j/RetryCallFactoryTest.kt
@@ -1,14 +1,21 @@
 package net.niebes.resilience4j
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import com.github.tomakehurst.wiremock.stubbing.Scenario
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
-import mockwebserver3.RecordedRequest
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,14 +35,14 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
+@WireMockTest
 internal class RetryCallFactoryTest {
     companion object {
         const val MAX_ATTEMPTS = 3
     }
 
-    private val responseBody = "{ \"name\": \"The body with no name\" }"
+    private val responseBody = """{ "name": "The body with no name" }"""
     private val responseObject = NamedObject("The body with no name")
-    private lateinit var server: MockWebServer
     private lateinit var client: SomeClient
     private val retryConfig: RetryConfig =
         RetryConfig
@@ -46,11 +53,10 @@ internal class RetryCallFactoryTest {
             .build()
 
     @BeforeEach
-    fun before() {
-        server = MockWebServer()
-        server.start()
+    fun before(wmRuntimeInfo: WireMockRuntimeInfo) {
         client =
             createClient(
+                wmRuntimeInfo,
                 RetryCallFactory(
                     Retry.of("test", retryConfig).apply {
                         with(eventPublisher) {
@@ -64,7 +70,10 @@ internal class RetryCallFactoryTest {
             )
     }
 
-    private fun createClient(retryCallFactory: RetryCallFactory): SomeClient =
+    private fun createClient(
+        wmRuntimeInfo: WireMockRuntimeInfo,
+        retryCallFactory: RetryCallFactory,
+    ): SomeClient =
         Retrofit
             .Builder()
             .client(
@@ -76,76 +85,81 @@ internal class RetryCallFactoryTest {
                     .build()
             ).addConverterFactory(JacksonConverterFactory.create(jacksonObjectMapper()))
             .addCallAdapterFactory(retryCallFactory)
-            .baseUrl(baseUrl())
+            .baseUrl(wmRuntimeInfo.httpBaseUrl + "/")
             .build()
             .create(SomeClient::class.java)
 
-    private fun addResponse(mockResponse: MockResponse) = server.enqueue(mockResponse)
-
-    @AfterEach
-    fun after() {
-        server.close()
-    }
-
     @Test
     fun `should not retry with sucessfull response`() {
-        addResponse(
-            MockResponse(body = responseBody)
-        )
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withBody(responseBody)))
+
         val response = client.root().execute()
-        assertResponse(response, 200, responseObject)
-        val recordedRequests: List<RecordedRequest> = server.getRecordedRequests()
-        assertThat(recordedRequests.map { it.url.encodedPath }).containsExactly("/")
+
+        assertThat(response.code()).isEqualTo(200)
+        assertThat(response.body()).isEqualTo(responseObject)
+        verify(1, getRequestedFor(urlEqualTo("/")))
     }
 
     @Test
     fun `should use the first successful result within retry count`() {
-        repeat(MAX_ATTEMPTS - 1) {
-            addResponse(
-                MockResponse(code = 500, body = responseBody)
-            )
-        }
-        addResponse(
-            MockResponse(body = responseBody)
+        stubFor(
+            get(urlEqualTo("/"))
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+                .willSetStateTo("attempt2")
         )
-        val response = client.root().execute()
-        assertResponse(response, 200, responseObject)
-        val recordedRequests = server.getRecordedRequests()
+        stubFor(
+            get(urlEqualTo("/"))
+                .inScenario("retry")
+                .whenScenarioStateIs("attempt2")
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+                .willSetStateTo("attempt3")
+        )
+        stubFor(
+            get(urlEqualTo("/"))
+                .inScenario("retry")
+                .whenScenarioStateIs("attempt3")
+                .willReturn(aResponse().withBody(responseBody))
+        )
 
-        assertThat(recordedRequests.size).isEqualTo(MAX_ATTEMPTS)
+        val response = client.root().execute()
+
+        assertThat(response.code()).isEqualTo(200)
+        assertThat(response.body()).isEqualTo(responseObject)
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/")))
     }
 
     @Test
     fun rootWithTimeout() {
+        stubFor(get(urlEqualTo("/")).willReturn(aResponse().withFixedDelay(5000)))
+
         Assertions.assertThrows(SocketTimeoutException::class.java) {
             client.root().execute()
         }
 
-        val actual = server.getRecordedRequests().map { it.url.encodedPath }
-        assertThat(actual).containsExactly("/", "/", "/")
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/")))
     }
 
     @Test
     fun `should not retry POST by default`() {
-        addResponse(
-            MockResponse(code = 500, body = responseBody)
+        stubFor(
+            post(urlEqualTo("/new/nonidempotent/transaction"))
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
         )
+
         client.createTransaction().execute()
 
-        assertThat(
-            server.getRecordedRequests().map { it.url.encodedPath }
-        ).containsExactly("/new/nonidempotent/transaction")
+        verify(1, postRequestedFor(urlEqualTo("/new/nonidempotent/transaction")))
     }
 
     @Test
-    fun `should retry POST when configured`() {
+    fun `should retry POST when configured`(wmRuntimeInfo: WireMockRuntimeInfo) {
         client =
             createClient(
+                wmRuntimeInfo,
                 RetryCallFactory(
-                    Retry.of(
-                        "test",
-                        retryConfig
-                    )
+                    Retry.of("test", retryConfig)
                 ) {
                     method == "GET" ||
                         setOf(
@@ -153,32 +167,41 @@ internal class RetryCallFactoryTest {
                         ).contains(url.pathSegments)
                 }
             )
-        repeat(MAX_ATTEMPTS) {
-            addResponse(
-                MockResponse(code = 500, body = responseBody)
-            )
-        }
+        stubFor(
+            post(urlEqualTo("/new/nonidempotent/transaction"))
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+        )
 
         client.createTransaction().execute()
 
-        assertThat(server.getRecordedRequests().map { it.url.encodedPath }).containsExactly(
-            "/new/nonidempotent/transaction",
-            "/new/nonidempotent/transaction",
-            "/new/nonidempotent/transaction"
-        )
+        verify(MAX_ATTEMPTS, postRequestedFor(urlEqualTo("/new/nonidempotent/transaction")))
     }
 
     @Test
     fun `should retry on async requests`() {
-        addResponse(
-            MockResponse(code = 500, body = responseBody)
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .inScenario("async-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+                .willSetStateTo("attempt2")
         )
-        addResponse(
-            MockResponse(code = 500, body = responseBody)
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .inScenario("async-retry")
+                .whenScenarioStateIs("attempt2")
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+                .willSetStateTo("attempt3")
         )
-        addResponse(MockResponse(body = responseBody))
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .inScenario("async-retry")
+                .whenScenarioStateIs("attempt3")
+                .willReturn(aResponse().withBody(responseBody))
+        )
         val latch = CountDownLatch(1)
         val successes = AtomicInteger(0)
+
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
             object : Callback<NamedObject> {
                 override fun onResponse(
@@ -197,24 +220,21 @@ internal class RetryCallFactoryTest {
                 }
             }
         )
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
+
+        latch.await(1, TimeUnit.SECONDS)
         assertThat(successes.get()).isEqualTo(1)
-        assertThat(server.getRecordedRequests().map { it.url.encodedPath }).containsExactly(
-            "/api/users/userId/foo",
-            "/api/users/userId/foo",
-            "/api/users/userId/foo"
-        )
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/api/users/userId/foo")))
     }
 
     @Test
     fun `should report success when no exception thrown`() {
-        repeat(MAX_ATTEMPTS) {
-            addResponse(
-                MockResponse(code = 500, body = responseBody)
-            )
-        }
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+        )
         val latch = CountDownLatch(1)
         val successes = AtomicInteger(0)
+
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
             object : Callback<NamedObject> {
                 override fun onResponse(
@@ -233,19 +253,21 @@ internal class RetryCallFactoryTest {
                 }
             }
         )
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
+
+        latch.await(1, TimeUnit.SECONDS)
         assertThat(successes.get()).isEqualTo(1)
-        assertThat(server.getRecordedRequests().map { it.url.encodedPath }).containsExactly(
-            "/api/users/userId/foo",
-            "/api/users/userId/foo",
-            "/api/users/userId/foo"
-        )
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/api/users/userId/foo")))
     }
 
     @Test
     fun `should report error when all async calls threw exceptions`() {
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .willReturn(aResponse().withFixedDelay(5000))
+        )
         val latch = CountDownLatch(1)
         val failures = AtomicInteger(0)
+
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
             object : Callback<NamedObject> {
                 override fun onResponse(
@@ -265,27 +287,19 @@ internal class RetryCallFactoryTest {
             }
         )
 
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
+        latch.await(1, TimeUnit.SECONDS)
         assertThat(failures.get()).isEqualTo(1)
-
-        assertThat(server.getRecordedRequests().map { it.url.encodedPath }).containsExactly(
-            "/api/users/userId/foo",
-            "/api/users/userId/foo",
-            "/api/users/userId/foo"
-        )
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/api/users/userId/foo")))
     }
 
     @Test
     fun `should report success when retry condition not met but now exception thrown`() {
-        repeat(MAX_ATTEMPTS) {
-            addResponse(
-                MockResponse(
-                    code = 500,
-                    body = responseBody
-                )
-            )
-        }
+        stubFor(
+            get(urlEqualTo("/api/users/userId/foo"))
+                .willReturn(aResponse().withStatus(500).withBody(responseBody))
+        )
         val latch = CountDownLatch(MAX_ATTEMPTS)
+
         client.getWithPlaceHolderValue("userId", "headerValue").enqueue(
             object : Callback<NamedObject> {
                 override fun onResponse(
@@ -303,33 +317,11 @@ internal class RetryCallFactoryTest {
                 }
             }
         )
-        latch.await(1, TimeUnit.SECONDS) // wait for async to complete
-        assertThat(server.getRecordedRequests().map { it.url.encodedPath }).containsExactly(
-            "/api/users/userId/foo",
-            "/api/users/userId/foo",
-            "/api/users/userId/foo"
-        )
+
+        latch.await(1, TimeUnit.SECONDS)
+        verify(MAX_ATTEMPTS, getRequestedFor(urlEqualTo("/api/users/userId/foo")))
     }
 
-    private fun MockWebServer.getRecordedRequests(maxDuration: Duration = Duration.ofMillis(100)): List<RecordedRequest> =
-        generateSequence {
-            takeRequest(maxDuration.toMillis(), TimeUnit.MILLISECONDS)
-        }.toList()
-
-    private fun baseUrl() = server.url("/").toString()
-
-    private fun assertResponse(
-        response: Response<NamedObject>,
-        status: Int,
-        body: Any?,
-    ) {
-        assertThat(response.code()).isEqualTo(status)
-        assertThat(response.body()).isEqualTo(body)
-    }
-
-    /**
-     * A test client interface
-     */
     interface SomeClient {
         @GET("/")
         fun root(): Call<NamedObject>
@@ -344,9 +336,6 @@ internal class RetryCallFactoryTest {
         ): Call<NamedObject>
     }
 
-    /**
-     * A test data class
-     */
     data class NamedObject(
         val name: String,
     )


### PR DESCRIPTION
## Summary

- Replace `mockwebserver3-junit5` with **WireMock 3.13.0** across all 4 modules
- Tests use `@WireMockTest` annotation, declarative stubs via `stubFor()`, and request verification via `verify()`
- Sequential responses for retry tests use WireMock scenarios
- Custom HTTP methods use `any()` matcher instead of method-specific matchers

## Test plan

- [ ] `./mvnw verify` passes all modules (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)