### PR TITLE
fix mockito scope, internal visibility, and async tag docs

### DIFF
--- a/retrofit-metrics-micrometer/README.md
+++ b/retrofit-metrics-micrometer/README.md
@@ -6,7 +6,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | base_url  | base_url                                         |
 | uri       | uri with placeholders                            |
 | method    | http method                                      |
-| async     | true for `execute()` false for `enqueue()`       |
+| async     | false for `execute()`, true for `enqueue()`       |
 | status    | response status or `Exception`                   |
 | series    | response status family or `EXCEPTION`            |
 | exception | `simpleName` of the response exception or `None` |

--- a/retrofit-metrics-statsd/README.md
+++ b/retrofit-metrics-statsd/README.md
@@ -6,7 +6,7 @@ this plugin adds rate and p99 metrics into `http.client.requests` for all reques
 | base_url  | base_url                                         |
 | uri       | uri with placeholders                            |
 | method    | http method                                      |
-| async     | true for `execute()` false for `enqueue()`       |
+| async     | false for `execute()`, true for `enqueue()`       |
 | status    | response status or `Exception`                   |
 | series    | response status family or `EXCEPTION`            |
 | exception | `simpleName` of the response exception or `None` |

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/retrofit-metrics/README.md
+++ b/retrofit-metrics/README.md
@@ -7,7 +7,7 @@ this plugin creates metrics with tags.
 | base_url  | base_url                                         |
 | uri       | uri with placeholders                            |
 | method    | http method                                      |
-| async     | true for `execute()` false for `enqueue()`       |
+| async     | false for `execute()`, true for `enqueue()`       |
 | status    | response status or `Exception`                   |
 | series    | response status family or `EXCEPTION`            |
 | exception | `simpleName` of the response exception or `None` |

--- a/retrofit-resilience4j-retry/src/main/kotlin/net/niebes/resilience4j/RetryCallAdapter.kt
+++ b/retrofit-resilience4j-retry/src/main/kotlin/net/niebes/resilience4j/RetryCallAdapter.kt
@@ -6,7 +6,7 @@ import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type
 
-class RetryCallAdapter<OriginalType, TargetType : Any>(
+internal class RetryCallAdapter<OriginalType, TargetType : Any>(
     private val nextCallAdapter: CallAdapter<OriginalType, TargetType>,
     private val retry: Retry,
     private val shouldRetry: (Request) -> Boolean,


### PR DESCRIPTION
## Summary

- Add missing `<scope>test</scope>` to mockito-core in retrofit-metrics-statsd (was leaking as compile dependency)
- Make `RetryCallAdapter` internal (implementation detail, not public API)
- Fix async tag description in all 3 metrics READMEs — `execute()` is sync, `enqueue()` is async (was documented backwards)
- Remove orphaned `io/` and `retrofit-retry/` directories

## Test plan

- [x] `./mvnw verify` passes all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)