### PR TITLE
fix null message in HttpResponseException and metrics test scope leak

### DIFF
--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -29,26 +29,32 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/HttpResponseException.kt
+++ b/retrofit-resilience4j/src/main/kotlin/net/niebes/retrofit/resilience4j/HttpResponseException.kt
@@ -2,5 +2,5 @@ package net.niebes.retrofit.resilience4j
 
 class HttpResponseException(
     val statusCode: Int,
-    message: String,
-) : RuntimeException("HTTP $statusCode - $message")
+    message: String?,
+) : RuntimeException("HTTP $statusCode" + if (message != null) " - $message" else "")

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/CircuitBreakerCallFactoryTest.kt
@@ -87,6 +87,26 @@ internal class CircuitBreakerCallFactoryTest {
     }
 
     @Test
+    fun `failed response records HttpResponseException with status code`(wmRuntimeInfo: WireMockRuntimeInfo) {
+        stubFor(get(urlEqualTo("/api/test")).willReturn(aResponse().withStatus(503).withBody("unavailable")))
+        val circuitBreaker =
+            CircuitBreaker.of(
+                "test-exception",
+                CircuitBreakerConfig
+                    .custom()
+                    .slidingWindowSize(1)
+                    .minimumNumberOfCalls(1)
+                    .recordException { it is HttpResponseException }
+                    .build()
+            )
+        val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))
+
+        client.get().execute()
+
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(1)
+    }
+
+    @Test
     fun `open circuit throws CallNotPermittedException on execute`(wmRuntimeInfo: WireMockRuntimeInfo) {
         circuitBreaker.transitionToOpenState()
         val client = createClient(wmRuntimeInfo, CircuitBreakerCallFactory(circuitBreaker))

--- a/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/HttpResponseExceptionTest.kt
+++ b/retrofit-resilience4j/src/test/kotlin/net/niebes/retrofit/resilience4j/HttpResponseExceptionTest.kt
@@ -1,0 +1,22 @@
+package net.niebes.retrofit.resilience4j
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class HttpResponseExceptionTest {
+    @Test
+    fun `formats message with status code and message`() {
+        val exception = HttpResponseException(503, "Service Unavailable")
+
+        assertThat(exception.message).isEqualTo("HTTP 503 - Service Unavailable")
+        assertThat(exception.statusCode).isEqualTo(503)
+    }
+
+    @Test
+    fun `handles null message`() {
+        val exception = HttpResponseException(502, null)
+
+        assertThat(exception.message).isEqualTo("HTTP 502")
+        assertThat(exception.statusCode).isEqualTo(502)
+    }
+}


### PR DESCRIPTION
## Summary

- Make `HttpResponseException.message` nullable — `response.message()` can return null in HTTP/2, causing NPE at runtime
- Add missing `<scope>test</scope>` to all test dependencies in `retrofit-metrics/pom.xml` (junit, assertj, wiremock, jackson were leaking into the published artifact)
- Add test verifying `HttpResponseException` is recorded by the circuit breaker when the success predicate rejects a response

## Test plan

- [x] `./mvnw verify` passes all 6 modules (73 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)