### PR TITLE
Disable pushChanges in maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
-                            <keyname>5F73B91A736B558A83CFFE6C8F9425EE2F569085</keyname>
+                            <keyname>927993B7B82F199016055909E7347F989651794C</keyname>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+                        <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.20.0-SNAPSHOT</version>
+    <version>1.20.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j</module>
@@ -20,7 +19,7 @@
         <url>https://github.com/niebes/retrofit-plugins</url>
         <connection>scm:git:git@github.com:niebes/retrofit-plugins.git</connection>
         <developerConnection>scm:git:git@github.com:niebes/retrofit-plugins.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>1.20.0</tag>
     </scm>
 
     <licenses>
@@ -286,7 +285,7 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <configuration>
                     <rules>
-                        <dependencyConvergence/>
+                        <dependencyConvergence />
                     </rules>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.niebes</groupId>
     <artifactId>retrofit-plugins</artifactId>
-    <version>1.20.0</version>
+    <version>1.21.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>retrofit-resilience4j</module>
@@ -19,7 +19,7 @@
         <url>https://github.com/niebes/retrofit-plugins</url>
         <connection>scm:git:git@github.com:niebes/retrofit-plugins.git</connection>
         <developerConnection>scm:git:git@github.com:niebes/retrofit-plugins.git</developerConnection>
-        <tag>1.20.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics-micrometer</name>
@@ -14,7 +14,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.20.0</version>
+                <version>1.21.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics-micrometer</name>
@@ -15,7 +14,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.20.0-SNAPSHOT</version>
+                <version>1.20.0</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -34,7 +33,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.20.0</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics-statsd</name>
@@ -15,7 +14,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.20.0-SNAPSHOT</version>
+                <version>1.20.0</version>
             </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
@@ -33,7 +32,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.20.0</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics-statsd</name>
@@ -14,7 +14,7 @@
             <dependency>
                 <groupId>net.niebes</groupId>
                 <artifactId>retrofit-metrics</artifactId>
-                <version>1.20.0</version>
+                <version>1.21.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>net.niebes</groupId>
             <artifactId>retrofit-metrics</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics</name>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>retrofit-metrics</name>

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j/pom.xml
+++ b/retrofit-resilience4j/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/retrofit-resilience4j/pom.xml
+++ b/retrofit-resilience4j/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>retrofit-plugins</artifactId>
         <groupId>net.niebes</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary
- Set `<pushChanges>false</pushChanges>` in the maven-release-plugin config
- The plugin can't push directly to the protected `develop` branch, which caused `release:prepare` to silently fail on the push step

## Release workflow (updated)

```sh
# 1. Prepare: version bump, commit, tag — all local
./mvnw release:prepare

# 2. Push the two commits and the tag manually
git push origin develop --tags

# 3. Perform: checkout tag, deploy to Maven Central
./mvnw release:perform
```

## Test plan
- [ ] `./mvnw release:prepare -DdryRun=true` completes
- [ ] Full `release:prepare` → manual push → `release:perform` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)