### PR TITLE
Add slf4j-simple test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,17 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.18</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>2.0.18</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>converter-jackson</artifactId>
                 <version>${retrofit.version}</version>

--- a/retrofit-metrics-micrometer/pom.xml
+++ b/retrofit-metrics-micrometer/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <scope>test</scope>

--- a/retrofit-metrics-statsd/pom.xml
+++ b/retrofit-metrics-statsd/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <scope>test</scope>

--- a/retrofit-metrics/pom.xml
+++ b/retrofit-metrics/pom.xml
@@ -46,6 +46,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <scope>test</scope>

--- a/retrofit-resilience4j-retry/pom.xml
+++ b/retrofit-resilience4j-retry/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <scope>test</scope>

--- a/retrofit-resilience4j/pom.xml
+++ b/retrofit-resilience4j/pom.xml
@@ -73,6 +73,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-scalars</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- Add `slf4j-simple:2.0.18` as a test dependency to all modules to fix WireMock's `SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"` warnings during test runs
- Align `slf4j-api` to 2.0.18 in `dependencyManagement` so the resilience4j modules (which pulled 1.7.30 transitively) use the same SLF4J version as the metrics modules

## Test plan
- [x] `./mvnw verify` passes with no SLF4J warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)